### PR TITLE
[refactor] 이미지 url s3 연결 & 거리순 정렬 수정

### DIFF
--- a/src/main/java/com/example/fitpassserver/domain/fitness/controller/response/FitnessDetailResponse.java
+++ b/src/main/java/com/example/fitpassserver/domain/fitness/controller/response/FitnessDetailResponse.java
@@ -18,4 +18,6 @@ public class FitnessDetailResponse {
     private Integer fee;
     private Double distance;
     private String imageUrl;
+    private Double fitnessLatitude;
+    private Double fitnessLongitude;
 }

--- a/src/main/java/com/example/fitpassserver/domain/fitness/controller/response/FitnessDetailResponse.java
+++ b/src/main/java/com/example/fitpassserver/domain/fitness/controller/response/FitnessDetailResponse.java
@@ -17,4 +17,5 @@ public class FitnessDetailResponse {
     private String etc;
     private Integer fee;
     private Double distance;
+    private String imageUrl;
 }

--- a/src/main/java/com/example/fitpassserver/domain/fitness/controller/response/FitnessListResponse.java
+++ b/src/main/java/com/example/fitpassserver/domain/fitness/controller/response/FitnessListResponse.java
@@ -13,5 +13,6 @@ public class FitnessListResponse {
     private String address;
     private Double distance; // 거리
     private Integer fee;
-    private String categoryName; // 카테고리 이름
+    private String categoryName;
+    private String imageUrl;
 }

--- a/src/main/java/com/example/fitpassserver/domain/fitness/controller/response/FitnessRecommendResponse.java
+++ b/src/main/java/com/example/fitpassserver/domain/fitness/controller/response/FitnessRecommendResponse.java
@@ -9,4 +9,5 @@ public class FitnessRecommendResponse {
     private Long fitnessId;
     private String name;
     private double distance;
+    private String imageUrl;
 }

--- a/src/main/java/com/example/fitpassserver/domain/fitness/controller/response/FitnessSearchResponse.java
+++ b/src/main/java/com/example/fitpassserver/domain/fitness/controller/response/FitnessSearchResponse.java
@@ -14,4 +14,5 @@ public class FitnessSearchResponse {
     private String address;
     private Integer fee;
     private double distance;
+    private String imageUrl;
 }

--- a/src/main/java/com/example/fitpassserver/domain/fitness/service/FitnessDetailService.java
+++ b/src/main/java/com/example/fitpassserver/domain/fitness/service/FitnessDetailService.java
@@ -7,15 +7,18 @@ import com.example.fitpassserver.domain.fitness.exception.FitnessErrorCode;
 import com.example.fitpassserver.domain.fitness.exception.FitnessException;
 import com.example.fitpassserver.domain.fitness.repository.FitnessRepository;
 import com.example.fitpassserver.domain.fitness.util.DistanceCalculator;
+import com.example.fitpassserver.global.aws.s3.service.S3Service;
 import org.springframework.stereotype.Service;
 import java.util.stream.Collectors;
 
 @Service
 public class FitnessDetailService {
     private final FitnessRepository fitnessRepository;
+    private final S3Service s3Service;
 
-    public FitnessDetailService(FitnessRepository fitnessRepository) {
+    public FitnessDetailService(FitnessRepository fitnessRepository, S3Service s3Service) {
         this.fitnessRepository = fitnessRepository;
+        this.s3Service = s3Service;
     }
     public FitnessDetailResponse getFitnessDetail(Long fitnessId, double userLatitude, double userLongitude) {
         Fitness fitness = fitnessRepository.findById(fitnessId)
@@ -25,6 +28,9 @@ public class FitnessDetailService {
                 userLatitude, userLongitude,
                 fitness.getLatitude(), fitness.getLongitude()
         );
+        String key = "fitness/default.png";
+        String imageUrl = s3Service.getGetS3Url(null, key).getPreSignedUrl();
+
         String categories = fitness.getCategoryList().stream()
                 .map(Category::getCategoryName)
                 .collect(Collectors.joining(", "));
@@ -41,6 +47,7 @@ public class FitnessDetailService {
                 .etc(fitness.getEtc())
                 .fee(fitness.getFee())
                 .distance(distance)
+                .imageUrl(imageUrl)
                 .build();
     }
 }

--- a/src/main/java/com/example/fitpassserver/domain/fitness/service/FitnessDetailService.java
+++ b/src/main/java/com/example/fitpassserver/domain/fitness/service/FitnessDetailService.java
@@ -48,6 +48,8 @@ public class FitnessDetailService {
                 .fee(fitness.getFee())
                 .distance(distance)
                 .imageUrl(imageUrl)
+                .fitnessLatitude(fitness.getLatitude())
+                .fitnessLongitude(fitness.getLongitude())
                 .build();
     }
 }

--- a/src/main/java/com/example/fitpassserver/domain/fitness/service/FitnessListService.java
+++ b/src/main/java/com/example/fitpassserver/domain/fitness/service/FitnessListService.java
@@ -6,6 +6,7 @@ import com.example.fitpassserver.domain.fitness.entity.Fitness;
 import com.example.fitpassserver.domain.fitness.entity.Category;
 import com.example.fitpassserver.domain.fitness.repository.FitnessRepository;
 import com.example.fitpassserver.domain.fitness.util.DistanceCalculator;
+import com.example.fitpassserver.global.aws.s3.service.S3Service;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -16,9 +17,11 @@ import java.util.stream.Collectors;
 @Service
 public class FitnessListService {
     private final FitnessRepository fitnessRepository;
+    private final S3Service s3Service;
 
-    public FitnessListService(FitnessRepository fitnessRepository) {
+    public FitnessListService(FitnessRepository fitnessRepository, S3Service s3Service) {
         this.fitnessRepository = fitnessRepository;
+        this.s3Service = s3Service;
     }
 
     public CursorPaginationResponse<FitnessListResponse> getFitnessList(
@@ -37,6 +40,10 @@ public class FitnessListService {
                             userLatitude, userLongitude,
                             fitness.getLatitude(), fitness.getLongitude()
                     );
+
+                    String key = "fitness/default.png";
+                    String imageUrl = s3Service.getGetS3Url(null, key).getPreSignedUrl();
+
                     String categories = fitness.getCategoryList().stream()
                             .map(Category::getCategoryName)
                             .collect(Collectors.joining(", "));
@@ -47,7 +54,8 @@ public class FitnessListService {
                             fitness.getAddress(),
                             distance,
                             fitness.getFee(),
-                            categories
+                            categories,
+                            imageUrl
                     );
                 })
                 .collect(Collectors.toList());

--- a/src/main/java/com/example/fitpassserver/domain/fitness/service/FitnessRecommendService.java
+++ b/src/main/java/com/example/fitpassserver/domain/fitness/service/FitnessRecommendService.java
@@ -4,6 +4,7 @@ import com.example.fitpassserver.domain.fitness.controller.response.FitnessRecom
 import com.example.fitpassserver.domain.fitness.entity.Fitness;
 import com.example.fitpassserver.domain.fitness.repository.FitnessRepository;
 import com.example.fitpassserver.domain.fitness.util.DistanceCalculator;
+import com.example.fitpassserver.global.aws.s3.service.S3Service;
 import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -11,9 +12,11 @@ import java.util.stream.Collectors;
 @Service
 public class FitnessRecommendService {
     private final FitnessRepository fitnessRepository;
+    private final S3Service s3Service;
 
-    public FitnessRecommendService(FitnessRepository fitnessRepository) {
+    public FitnessRecommendService(FitnessRepository fitnessRepository,  S3Service s3Service) {
         this.fitnessRepository = fitnessRepository;
+        this.s3Service = s3Service;
     }
 
     public List<Fitness> getRecommendFitness() {
@@ -28,11 +31,14 @@ public class FitnessRecommendService {
                             userLatitude, userLongitude,
                             fitness.getLatitude(), fitness.getLongitude()
                     );
+                    String key = "fitness/default.png";
+                    String imageUrl = s3Service.getGetS3Url(null, key).getPreSignedUrl();
 
                     return FitnessRecommendResponse.builder()
                             .fitnessId(fitness.getId())
                             .name(fitness.getName())
                             .distance(distance)
+                            .imageUrl(imageUrl)
                             .build();
                 })
                 .collect(Collectors.toList());

--- a/src/main/java/com/example/fitpassserver/domain/fitness/util/DistanceCalculator.java
+++ b/src/main/java/com/example/fitpassserver/domain/fitness/util/DistanceCalculator.java
@@ -1,21 +1,25 @@
 package com.example.fitpassserver.domain.fitness.util;
+
 import org.springframework.stereotype.Service;
 
 @Service
 public class DistanceCalculator {
-    public static double distance(double lat1, double lon1, double lat2, double lon2){
+    public static double distance(double lat1, double lon1, double lat2, double lon2) {
         double theta = lon1 - lon2;
-        double dist = Math.sin(deg2rad(lat1))* Math.sin(deg2rad(lat2)) + Math.cos(deg2rad(lat1))*Math.cos(deg2rad(lat2))*Math.cos(deg2rad(theta));
+        double dist = Math.sin(deg2rad(lat1)) * Math.sin(deg2rad(lat2))
+                + Math.cos(deg2rad(lat1)) * Math.cos(deg2rad(lat2)) * Math.cos(deg2rad(theta));
         dist = Math.acos(dist);
         dist = rad2deg(dist);
-        dist = dist * 60*1.1515*1609.344;
-        return dist; //단위 meter
+        dist = dist * 60 * 1.1515 * 1.609344;
+        dist = Math.round(dist * 100) / 100.0;
+        return dist;
     }
-    private static double deg2rad(double deg){
-        return (deg * Math.PI/180.0);
+
+    private static double deg2rad(double deg) {
+        return (deg * Math.PI / 180.0);
     }
-    //radian(라디안)을 10진수로 변환
-    private static double rad2deg(double rad){
+
+    private static double rad2deg(double rad) {
         return (rad * 180 / Math.PI);
     }
 }

--- a/src/main/java/com/example/fitpassserver/domain/notice/controller/response/NoticeDetailResponse.java
+++ b/src/main/java/com/example/fitpassserver/domain/notice/controller/response/NoticeDetailResponse.java
@@ -7,6 +7,7 @@ public record NoticeDetailResponse(
         String title,
         String content,
         String noticeImage,
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+        String imageUrl
 ) {
 }

--- a/src/main/java/com/example/fitpassserver/domain/notice/service/NoticeService.java
+++ b/src/main/java/com/example/fitpassserver/domain/notice/service/NoticeService.java
@@ -6,6 +6,7 @@ import com.example.fitpassserver.domain.notice.entity.Notice;
 import com.example.fitpassserver.domain.notice.exception.NoticeErrorCode;
 import com.example.fitpassserver.domain.notice.exception.NoticeException;
 import com.example.fitpassserver.domain.notice.repository.NoticeRepository;
+import com.example.fitpassserver.global.aws.s3.service.S3Service;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -17,9 +18,11 @@ import java.util.stream.Collectors;
 @Service
 public class NoticeService {
     private final NoticeRepository noticeRepository;
+    private final S3Service s3Service;
 
-    public NoticeService(NoticeRepository noticeRepository) {
+    public NoticeService(NoticeRepository noticeRepository, S3Service s3Service) {
         this.noticeRepository = noticeRepository;
+        this.s3Service = s3Service;
     }
 
     public Map<String, Object> getNoticeList(Pageable pageable) {
@@ -42,12 +45,16 @@ public class NoticeService {
         Notice notice = noticeRepository.findById(noticeId)
                 .orElseThrow(() -> new NoticeException(NoticeErrorCode.NOTICE_NOT_FOUND));
 
+        String key = "notice/default.png";
+        String imageUrl = s3Service.getGetS3Url(null, key).getPreSignedUrl();
+
         return new NoticeDetailResponse(
                 notice.getId(),
                 notice.getTitle(),
                 notice.getContent(),
                 notice.getNoticeImage(),
-                notice.getCreatedAt()
+                notice.getCreatedAt(),
+                imageUrl
         );
     }
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #

## 📌 개요
- 이미지 url s3 연결 & 거리순 정렬 수정
- 지금은 이미지 default.png 넣어놓고 그거 가져오게 해놨습니다. 어드민 페이지 만들고(이미지 등록을 어드민에서 하니까)  url key 값 부분 수정하면 될 것 같습니다.

## 🔁 변경 사항 (커밋 코드와 함께)
18a091be890c6b17ce4a2919519ae81fa1843576
필터 조건이 distance 일 때 거리순으로 정렬이 안되고 있어 수정하였음

0855368886a27f605b2fc1b7bfa86eca29c2cbc9
이미지를 s3 버킷에서 가져오도록 수정

1d657a23f9f187607b4b2389b78786a0dafc2830
시설 위도 경도 값 detail 페이지에서 필요, 단위 km로 변경
## 📸 스크린샷 (필수 x)

## 👀 기타 더 이야기해볼 점 (필수 x)

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
