### PR TITLE
✨ [Feat] 어드민 사용자 조회 기능

### DIFF
--- a/src/main/java/com/example/fitpassserver/admin/member/controller/MemberAdminController.java
+++ b/src/main/java/com/example/fitpassserver/admin/member/controller/MemberAdminController.java
@@ -27,9 +27,10 @@ public class MemberAdminController {
     public ApiResponse<?> getMembersPage(
             @Parameter(description = "현재 인증된 사용자 정보", hidden = true) @CurrentMember Member member,
             @Parameter(description = "페이지 시작 오프셋 (기본값: 0)", example = "0") @RequestParam(defaultValue = "0") int page,
-            @Parameter(description = "페이지 당 엘리먼트 개수 (기본값: 10)", example = "10") @RequestParam(defaultValue = "5") int size,
-            @Parameter(description = "정렬 기준 (기본값: id)", example = "id") @RequestParam(defaultValue = "id") String sortBy) {
-        MemberAdminResponseDTO.MemberPagesDTO membersInfo = memberAdminService.getMembersInfo(page, size, sortBy);
+            @Parameter(description = "페이지 당 엘리먼트 개수 (기본값: 10)", example = "10") @RequestParam(defaultValue = "10") int size,
+            @Parameter(description = "검색 유형 (예: name, loginId, phoneNumber)", example = "name") @RequestParam(required = false) String searchType,
+            @Parameter(description = "검색 키워드", example = "핏패스") @RequestParam(required = false) String keyword) {
+        MemberAdminResponseDTO.MemberPagesDTO membersInfo = memberAdminService.getMembersInfo(page, size, searchType, keyword);
         return ApiResponse.onSuccess(membersInfo);
     }
 

--- a/src/main/java/com/example/fitpassserver/admin/member/controller/MemberAdminController.java
+++ b/src/main/java/com/example/fitpassserver/admin/member/controller/MemberAdminController.java
@@ -1,4 +1,36 @@
 package com.example.fitpassserver.admin.member.controller;
 
+import com.example.fitpassserver.admin.member.dto.response.MemberAdminResponseDTO;
+import com.example.fitpassserver.admin.member.service.MemberAdminService;
+import com.example.fitpassserver.domain.member.annotation.CurrentMember;
+import com.example.fitpassserver.domain.member.entity.Member;
+import com.example.fitpassserver.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin")
 public class MemberAdminController {
+
+    private final MemberAdminService memberAdminService;
+
+    @Operation(summary = "어드민 사용자 정보 조회", description = "어드민이 사용자의 정보를 조회하는 API 입니다.")
+    @GetMapping("/members")
+    public ApiResponse<?> getMembersPage(
+            @Parameter(description = "현재 인증된 사용자 정보", hidden = true) @CurrentMember Member member,
+            @Parameter(description = "페이지 시작 오프셋 (기본값: 0)", example = "0") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지 당 엘리먼트 개수 (기본값: 10)", example = "10") @RequestParam(defaultValue = "5") int size,
+            @Parameter(description = "정렬 기준 (기본값: id)", example = "id") @RequestParam(defaultValue = "id") String sortBy) {
+        MemberAdminResponseDTO.MemberPagesDTO membersInfo = memberAdminService.getMembersInfo(page, size, sortBy);
+        return ApiResponse.onSuccess(membersInfo);
+    }
+
 }

--- a/src/main/java/com/example/fitpassserver/admin/member/converter/MemberAdminConverter.java
+++ b/src/main/java/com/example/fitpassserver/admin/member/converter/MemberAdminConverter.java
@@ -1,0 +1,30 @@
+package com.example.fitpassserver.admin.member.converter;
+
+import com.example.fitpassserver.admin.member.dto.response.MemberAdminResponseDTO;
+import com.example.fitpassserver.domain.member.entity.Member;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public class MemberAdminConverter {
+
+    public static MemberAdminResponseDTO.MemberPagesDTO toPageDTO(Page<Member> memberPage) {
+        List<MemberAdminResponseDTO.MemberInfosDTO> membersInfo = memberPage
+                .map(member -> MemberAdminResponseDTO.MemberInfosDTO.builder()
+                        .id(member.getId())
+                        .name(member.getName())
+                        .registerType(member.getProvider() != null ? "SNS 가입" : "회원 가입")
+                        .loginId(member.getLoginId())
+                        .phoneNumber(member.getPhoneNumber())
+                        .createdAt(member.getCreatedAt().toLocalDate())
+                        .build())
+                .getContent();
+
+        return MemberAdminResponseDTO.MemberPagesDTO.builder()
+                .membersInfo(membersInfo)
+                .totalPages(memberPage.getTotalPages())
+                .totalElements(memberPage.getTotalElements())
+                .build();
+    }
+}

--- a/src/main/java/com/example/fitpassserver/admin/member/converter/MemberAdminConverter.java
+++ b/src/main/java/com/example/fitpassserver/admin/member/converter/MemberAdminConverter.java
@@ -3,6 +3,7 @@ package com.example.fitpassserver.admin.member.converter;
 import com.example.fitpassserver.admin.member.dto.response.MemberAdminResponseDTO;
 import com.example.fitpassserver.domain.member.entity.Member;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import org.springframework.data.domain.Page;
@@ -18,6 +19,7 @@ public class MemberAdminConverter {
                         .loginId(member.getLoginId())
                         .phoneNumber(member.getPhoneNumber())
                         .createdAt(member.getCreatedAt().toLocalDate())
+                        .lastLoginAt(formatLastLoginAt(member.getLastLoginAt()))
                         .build())
                 .getContent();
 
@@ -26,5 +28,20 @@ public class MemberAdminConverter {
                 .totalPages(memberPage.getTotalPages())
                 .totalElements(memberPage.getTotalElements())
                 .build();
+    }
+
+    private static String formatLastLoginAt(LocalDateTime lastLoginAt) {
+        if (lastLoginAt == null) {
+            return "로그인 기록 없음";
+        }
+
+        LocalDate lastLoginDate = lastLoginAt.toLocalDate();
+        long daysAgo = ChronoUnit.DAYS.between(lastLoginDate, LocalDate.now());
+
+        if (daysAgo == 0) {
+            return "오늘";
+        } else {
+            return daysAgo + "일전";
+        }
     }
 }

--- a/src/main/java/com/example/fitpassserver/admin/member/dto/response/MemberAdminResponseDTO.java
+++ b/src/main/java/com/example/fitpassserver/admin/member/dto/response/MemberAdminResponseDTO.java
@@ -1,0 +1,29 @@
+package com.example.fitpassserver.admin.member.dto.response;
+
+import java.time.LocalDate;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+public class MemberAdminResponseDTO {
+
+    @Getter
+    @Builder
+    public static class MemberInfosDTO {
+        private Long id;
+        private String name;
+        private String registerType;
+        private String loginId;
+        private String phoneNumber;
+        private LocalDate createdAt;
+        private String lastLoginAt;
+    }
+
+    @Getter
+    @Builder
+    public static class MemberPagesDTO {
+        List<MemberInfosDTO> membersInfo;
+        private int totalPages;
+        private long totalElements;
+    }
+}

--- a/src/main/java/com/example/fitpassserver/admin/member/service/MemberAdminService.java
+++ b/src/main/java/com/example/fitpassserver/admin/member/service/MemberAdminService.java
@@ -4,5 +4,5 @@ import com.example.fitpassserver.admin.member.dto.response.MemberAdminResponseDT
 import org.springframework.data.domain.Page;
 
 public interface MemberAdminService {
-    MemberAdminResponseDTO.MemberPagesDTO getMembersInfo(int page, int size, String sortBy);
+    MemberAdminResponseDTO.MemberPagesDTO getMembersInfo(int page, int size, String searchType, String keyword);
 }

--- a/src/main/java/com/example/fitpassserver/admin/member/service/MemberAdminService.java
+++ b/src/main/java/com/example/fitpassserver/admin/member/service/MemberAdminService.java
@@ -1,4 +1,8 @@
 package com.example.fitpassserver.admin.member.service;
 
-public class MemberAdminService {
+import com.example.fitpassserver.admin.member.dto.response.MemberAdminResponseDTO;
+import org.springframework.data.domain.Page;
+
+public interface MemberAdminService {
+    MemberAdminResponseDTO.MemberPagesDTO getMembersInfo(int page, int size, String sortBy);
 }

--- a/src/main/java/com/example/fitpassserver/admin/member/service/MemberAdminServiceImpl.java
+++ b/src/main/java/com/example/fitpassserver/admin/member/service/MemberAdminServiceImpl.java
@@ -1,4 +1,28 @@
 package com.example.fitpassserver.admin.member.service;
 
-public interface MemberAdminServiceImpl {
+import com.example.fitpassserver.admin.member.converter.MemberAdminConverter;
+import com.example.fitpassserver.admin.member.dto.response.MemberAdminResponseDTO;
+import com.example.fitpassserver.admin.member.dto.response.MemberAdminResponseDTO.MemberInfosDTO;
+import com.example.fitpassserver.domain.member.entity.Member;
+import com.example.fitpassserver.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberAdminServiceImpl implements MemberAdminService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public MemberAdminResponseDTO.MemberPagesDTO getMembersInfo(int page, int size, String sortBy) {
+        Sort sort = Sort.by(Sort.Order.desc("id"));
+        Pageable pageable = PageRequest.of(page, size, sort);
+        Page<Member> memberPage = memberRepository.findAll(pageable);
+        return MemberAdminConverter.toPageDTO(memberPage);
+    }
 }

--- a/src/main/java/com/example/fitpassserver/admin/member/service/MemberAdminServiceImpl.java
+++ b/src/main/java/com/example/fitpassserver/admin/member/service/MemberAdminServiceImpl.java
@@ -5,12 +5,14 @@ import com.example.fitpassserver.admin.member.dto.response.MemberAdminResponseDT
 import com.example.fitpassserver.admin.member.dto.response.MemberAdminResponseDTO.MemberInfosDTO;
 import com.example.fitpassserver.domain.member.entity.Member;
 import com.example.fitpassserver.domain.member.repository.MemberRepository;
+import io.netty.util.internal.StringUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 @Service
 @RequiredArgsConstructor
@@ -19,10 +21,30 @@ public class MemberAdminServiceImpl implements MemberAdminService {
     private final MemberRepository memberRepository;
 
     @Override
-    public MemberAdminResponseDTO.MemberPagesDTO getMembersInfo(int page, int size, String sortBy) {
+    public MemberAdminResponseDTO.MemberPagesDTO getMembersInfo(int page, int size, String searchType, String keyword) {
         Sort sort = Sort.by(Sort.Order.desc("id"));
-        Pageable pageable = PageRequest.of(page, size, sort);
-        Page<Member> memberPage = memberRepository.findAll(pageable);
+        PageRequest pageRequest = PageRequest.of(page, size, sort);
+
+        Page<Member> memberPage;
+
+        if (!StringUtils.hasText(searchType) || !StringUtils.hasText(keyword)) {
+            memberPage = memberRepository.findAll(pageRequest);
+        } else {
+            switch (searchType) {
+                case "name":
+                    memberPage = memberRepository.findByNameContaining(keyword, pageRequest);
+                    break;
+                case "loginId":
+                    memberPage = memberRepository.findByLoginIdContaining(keyword, pageRequest);
+                    break;
+                case "phoneNumber":
+                    memberPage = memberRepository.findByPhoneNumberContaining(keyword, pageRequest);
+                    break;
+                default:
+                    memberPage = memberRepository.findAll(pageRequest);
+            }
+        }
+
         return MemberAdminConverter.toPageDTO(memberPage);
     }
 }

--- a/src/main/java/com/example/fitpassserver/domain/member/entity/Member.java
+++ b/src/main/java/com/example/fitpassserver/domain/member/entity/Member.java
@@ -92,6 +92,9 @@ public class Member extends BaseEntity {
     @Column(name = "is_additional_info")
     private boolean isAdditionalInfo;
 
+    @Column(name = "last_login_at")
+    private LocalDateTime lastLoginAt;
+
     @Builder.Default
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<Coin> CoinList = new ArrayList<>();
@@ -146,5 +149,9 @@ public class Member extends BaseEntity {
 
     public void updatePassword(String newPassword) {
         this.password = newPassword;
+    }
+
+    public void updateLastLoginAt(LocalDateTime lastLoginAt) {
+        this.lastLoginAt = lastLoginAt;
     }
 }

--- a/src/main/java/com/example/fitpassserver/domain/member/principal/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/fitpassserver/domain/member/principal/CustomOAuth2UserService.java
@@ -42,11 +42,12 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 
         Member createdMember = getMember(extractAttributes);
 
-        Profile profile = Profile.builder()
-                .member(createdMember)
-                .pictureKey("none")
-                .pictureUrl("none")
-                .build();
+        Profile profile = profileRepository.findProfileByMemberId(createdMember.getId())
+                .orElseGet(() -> Profile.builder()
+                        .member(createdMember)
+                        .pictureKey("none")
+                        .pictureUrl("none")
+                        .build());
 
         profileRepository.save(profile);
 

--- a/src/main/java/com/example/fitpassserver/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/fitpassserver/domain/member/repository/MemberRepository.java
@@ -2,6 +2,8 @@ package com.example.fitpassserver.domain.member.repository;
 
 import com.example.fitpassserver.domain.member.entity.Member;
 import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -19,4 +21,9 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByName(String name);
 
+    Page<Member> findByNameContaining(String name, Pageable pageable);
+
+    Page<Member> findByLoginIdContaining(String loginId, Pageable pageable);
+
+    Page<Member> findByPhoneNumberContaining(String phoneNumber, Pageable pageable);
 }

--- a/src/main/java/com/example/fitpassserver/domain/member/service/command/MemberCommandServiceImpl.java
+++ b/src/main/java/com/example/fitpassserver/domain/member/service/command/MemberCommandServiceImpl.java
@@ -14,6 +14,7 @@ import com.example.fitpassserver.domain.member.sms.service.SmsService;
 import com.example.fitpassserver.domain.profile.entity.Profile;
 import com.example.fitpassserver.domain.profile.repositroy.ProfileRepository;
 import com.example.fitpassserver.global.jwt.util.JwtProvider;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -76,6 +77,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
      * 로그인
      **/
     @Override
+    @Transactional
     public MemberResponseDTO.MemberTokenDTO login(MemberRequestDTO.LoginDTO dto) {
         Member member = memberRepository.findByLoginId(dto.getLoginId())
                 .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
@@ -88,6 +90,8 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         if (!passwordEncoder.matches(dto.getPassword(), member.getPassword())) {
             throw new MemberException(MemberErrorCode.INCORRECT_PASSWORD);
         }
+
+        member.updateLastLoginAt(LocalDateTime.now());
 
         return MemberResponseDTO.MemberTokenDTO.builder()
                 .accessToken(jwtProvider.createAccessToken(member))

--- a/src/main/java/com/example/fitpassserver/global/oauth/handler/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/com/example/fitpassserver/global/oauth/handler/CustomOAuth2SuccessHandler.java
@@ -6,10 +6,10 @@ import com.example.fitpassserver.domain.member.exception.MemberException;
 import com.example.fitpassserver.domain.member.principal.CustomOAuth2User;
 import com.example.fitpassserver.domain.member.repository.MemberRepository;
 import com.example.fitpassserver.global.jwt.util.JwtProvider;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.time.LocalDateTime;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
@@ -45,6 +45,8 @@ public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHa
 
         Member member = memberRepository.findById(oAuth2User.getId())
                 .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
+
+        member.updateLastLoginAt(LocalDateTime.now());
 
         String accessToken = jwtProvider.createAccessToken(member);
         String refreshToken = jwtProvider.createRefreshToken(member);


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #122 

## 📌 개요
- 어드민 사용자 조회 기능 추가
- 소셜 로그인 시 프로필 중복 생성 시도 오류 수정

## 🔁 변경 사항 (커밋 코드와 함께)
99c5424991956f06c5244543a7195731e98041cc
- 어드민 사용자 정보 조회 기능
56a4cd6979417c253c09523721b752e1e1a9b8bb
- 소셜 로그인 시 완전히 회원가입을 완료하기 전에 다시 소셜 로그인 시도 시 프로필 중복 생성하는 오류 수정
4daf7b887d6ec74788beeb6b042a978fffec1872
- 사용자 로그인 시 마지막 로그인 일자 저장하도록 함.
e8c2b7078e324ef44c29961b64bb2051fb8d9479
- 어드민 사용자 정보 조회 시 접속일 컬럼 추가
fd06eaf8a4e7c8507e9faec23351995b5d7fab42
- 어드민 사용자 정보 조회 시 검색 기능 추가

## 📸 스크린샷 (필수 x)

## 👀 기타 더 이야기해볼 점 (필수 x)

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
