### PR TITLE
♻️ [Refactor] 소셜 로그인 시 Role 반환 추가, 어드민 회원 정보 Swagger Tag 추가

### DIFF
--- a/src/main/java/com/example/fitpassserver/admin/member/controller/MemberAdminController.java
+++ b/src/main/java/com/example/fitpassserver/admin/member/controller/MemberAdminController.java
@@ -7,6 +7,7 @@ import com.example.fitpassserver.domain.member.entity.Member;
 import com.example.fitpassserver.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/admin")
+@Tag(name = "어드민 회원 정보 API", description = "어드민 회원 정보 API입니다.")
 public class MemberAdminController {
 
     private final MemberAdminService memberAdminService;

--- a/src/main/java/com/example/fitpassserver/global/oauth/handler/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/com/example/fitpassserver/global/oauth/handler/CustomOAuth2SuccessHandler.java
@@ -50,9 +50,11 @@ public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHa
 
         String accessToken = jwtProvider.createAccessToken(member);
         String refreshToken = jwtProvider.createRefreshToken(member);
+        String memberRole = member.getRole().toString();
 
         addCookie(response, "accessToken", accessToken, (int) (accessExpiration / 1000));
         addCookie(response, "refreshToken", refreshToken, (int) (refreshExpiration / 1000));
+        addCookie(response, "memberRole", memberRole, (int) (accessExpiration / 1000));
 
         if (!member.isAdditionalInfo()) {
             addCookie(response, "status", "register", 60 * 5);


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #146 

## 📌 개요
- 소셜 로그인 시 Role 반환 추가, 어드민 회원 정보 Swagger Tag 추가

## 🔁 변경 사항 (커밋 코드와 함께)
9ac35df7fcbaa9a7f2cf098c062a2889b350b89d
- 소셜 로그인 시 Role 반환
e44eaa668da6de8db9e794a14548e90f46bb9e32
- 어드민 회원 정보 컨트롤러 Swagger Tag 추가

## 📸 스크린샷 (필수 x)

## 👀 기타 더 이야기해볼 점 (필수 x)

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
