### PR TITLE
🐛 [Fix] 결제 내역 + 코인 엔티티 동시성 버그 해결 및 이벤트 추가 

### DIFF
--- a/src/main/java/com/example/fitpassserver/domain/coin/entity/Coin.java
+++ b/src/main/java/com/example/fitpassserver/domain/coin/entity/Coin.java
@@ -53,9 +53,14 @@ public class Coin extends BaseEntity {
     @JoinColumn(name = "history_id")
     private CoinPaymentHistory history;
 
+    public void setHistory(CoinPaymentHistory history) {
+        this.history = history;
+    }
+
     public void decreaseCount(Long count) {
         this.count -= count;
     }
+
     public void increaseCount(Long count) {
         this.count += count;
     }

--- a/src/main/java/com/example/fitpassserver/domain/coin/service/CoinService.java
+++ b/src/main/java/com/example/fitpassserver/domain/coin/service/CoinService.java
@@ -20,7 +20,6 @@ import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -60,11 +59,7 @@ public class CoinService {
     }
 
 
-    @Transactional
-    public Coin createSubscriptionNewCoin(Member member, CoinPaymentHistory history, Plan plan) {
-        if (!history.getMember().getId().equals(member.getId())) {
-            throw new CoinException(CoinErrorCode.COIN_UNAUTHORIZED_ERROR);
-        }
+    public Coin createSubscriptionNewCoin(Member member, Plan plan) {
         PlanType planType = plan.getPlanType();
         PlanTypeEntity planTypeEntity = planTypeRepository.findByPlanType(planType)
                 .orElseThrow(() -> new PlanException(PlanErrorCode.PLAN_NOT_FOUND));
@@ -74,7 +69,6 @@ public class CoinService {
                 .planType(planType)
                 .count((long) planTypeEntity.getCoinQuantity())
                 .expiredDate(LocalDate.now().plusDays(DEAD_LINE))
-                .history(history)
                 .build());
     }
 }

--- a/src/main/java/com/example/fitpassserver/domain/coinPaymentHistory/dto/event/CoinApprovedEvent.java
+++ b/src/main/java/com/example/fitpassserver/domain/coinPaymentHistory/dto/event/CoinApprovedEvent.java
@@ -1,0 +1,10 @@
+package com.example.fitpassserver.domain.coinPaymentHistory.dto.event;
+
+import com.example.fitpassserver.domain.coin.entity.Coin;
+import com.example.fitpassserver.domain.coinPaymentHistory.entity.CoinPaymentHistory;
+
+public record CoinApprovedEvent(
+        CoinPaymentHistory history,
+        Coin coin
+) {
+}

--- a/src/main/java/com/example/fitpassserver/domain/coinPaymentHistory/dto/event/CoinPaymentAllSuccessEvent.java
+++ b/src/main/java/com/example/fitpassserver/domain/coinPaymentHistory/dto/event/CoinPaymentAllSuccessEvent.java
@@ -1,0 +1,8 @@
+package com.example.fitpassserver.domain.coinPaymentHistory.dto.event;
+
+public record CoinPaymentAllSuccessEvent(
+        String phoneNumber,
+        int quantity,
+        int totalAmount
+) {
+}

--- a/src/main/java/com/example/fitpassserver/domain/coinPaymentHistory/dto/event/CoinSuccessEvent.java
+++ b/src/main/java/com/example/fitpassserver/domain/coinPaymentHistory/dto/event/CoinSuccessEvent.java
@@ -1,0 +1,11 @@
+package com.example.fitpassserver.domain.coinPaymentHistory.dto.event;
+
+import com.example.fitpassserver.domain.coinPaymentHistory.dto.response.KakaoPaymentApproveDTO;
+import com.example.fitpassserver.domain.member.entity.Member;
+
+public record CoinSuccessEvent(
+        Member member,
+        KakaoPaymentApproveDTO dto
+
+) {
+}

--- a/src/main/java/com/example/fitpassserver/domain/coinPaymentHistory/dto/response/CoinPaymentHistoryResponseListDTO.java
+++ b/src/main/java/com/example/fitpassserver/domain/coinPaymentHistory/dto/response/CoinPaymentHistoryResponseListDTO.java
@@ -20,7 +20,7 @@ public record CoinPaymentHistoryResponseListDTO(
             Long id,
             PlanType planType,
             boolean isAgree,
-            Long coinCount,
+            Integer coinCount,
             Integer price,
             LocalDateTime createdAt
     ) {

--- a/src/main/java/com/example/fitpassserver/domain/coinPaymentHistory/entity/CoinPaymentHistory.java
+++ b/src/main/java/com/example/fitpassserver/domain/coinPaymentHistory/entity/CoinPaymentHistory.java
@@ -53,7 +53,7 @@ public class CoinPaymentHistory extends BaseEntity {
     private Integer paymentPrice;
 
     @Column(name = "coin_count", nullable = false)
-    private Long coinCount;
+    private Integer coinCount;
     @OneToOne
     @JoinColumn(name = "coin_id")
     private Coin coin;

--- a/src/main/java/com/example/fitpassserver/domain/coinPaymentHistory/listener/CoinPaymentEventListener.java
+++ b/src/main/java/com/example/fitpassserver/domain/coinPaymentHistory/listener/CoinPaymentEventListener.java
@@ -1,0 +1,42 @@
+package com.example.fitpassserver.domain.coinPaymentHistory.listener;
+
+import com.example.fitpassserver.domain.coin.entity.Coin;
+import com.example.fitpassserver.domain.coin.service.CoinService;
+import com.example.fitpassserver.domain.coinPaymentHistory.dto.event.CoinPaymentAllSuccessEvent;
+import com.example.fitpassserver.domain.coinPaymentHistory.dto.event.CoinSuccessEvent;
+import com.example.fitpassserver.domain.coinPaymentHistory.entity.CoinPaymentHistory;
+import com.example.fitpassserver.domain.coinPaymentHistory.service.CoinPaymentHistoryService;
+import com.example.fitpassserver.domain.member.sms.util.SmsCertificationUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CoinPaymentEventListener {
+    private final SmsCertificationUtil smsCertificationUtil;
+    private final CoinPaymentHistoryService coinPaymentHistoryService;
+    private final CoinService coinService;
+
+    @EventListener
+    @Transactional
+    public void handle(CoinSuccessEvent event) {
+        Coin coin = coinService.createNewCoin(event.member(), event.dto());
+        CoinPaymentHistory history = coinPaymentHistoryService.createNewCoinPayment(event.member(), event.dto(), coin);
+        coinService.setCoinAndCoinPayment(coin, history);
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Async
+    public void handle(CoinPaymentAllSuccessEvent event) {
+        smsCertificationUtil.sendCoinPaymentSMS(event.phoneNumber(), event.quantity(), event.totalAmount());
+        log.info("{} 에게 문자 발송 완료", event.phoneNumber());
+    }
+
+}

--- a/src/main/java/com/example/fitpassserver/domain/coinPaymentHistory/service/CoinPaymentHistoryService.java
+++ b/src/main/java/com/example/fitpassserver/domain/coinPaymentHistory/service/CoinPaymentHistoryService.java
@@ -42,17 +42,18 @@ public class CoinPaymentHistoryService {
     private final PlanRepository planRepository;
     private final String KAKAOPAY = "kakaopay";
 
-    public CoinPaymentHistory createNewCoinPayment(Member member, String tid, KakaoPaymentApproveDTO dto) {
+    public CoinPaymentHistory createNewCoinPayment(Member member, KakaoPaymentApproveDTO dto, Coin coin) {
         int price = dto.amount().total();
         CoinTypeEntity coinType = coinTypeRepository.findByPrice(price)
                 .orElseThrow(() -> new CoinException(CoinErrorCode.COIN_NOT_FOUND));
         return coinPaymentRepository.save(CoinPaymentHistory.builder()
                 .paymentMethod(KAKAOPAY)
                 .isAgree(true)
-                .paymentStatus(PaymentStatus.READY)
-                .tid(tid)
+                .paymentStatus(PaymentStatus.SUCCESS)
+                .tid(dto.tid())
+                .coin(coin)
                 .member(member)
-                .coinCount(((long) coinType.getCoinQuantity() * dto.quantity()))
+                .coinCount((coinType.getCoinQuantity() * dto.quantity()))
                 .paymentPrice(dto.amount().total())
                 .build());
     }
@@ -69,7 +70,7 @@ public class CoinPaymentHistoryService {
                 .paymentMethod(KAKAOPAY)
                 .isAgree(true)
                 .tid(dto.tid())
-                .coinCount((long) planType.getCoinQuantity())
+                .coinCount(planType.getCoinQuantity())
                 .paymentStatus(PaymentStatus.READY)
                 .member(member)
                 .paymentPrice(dto.amount().total())
@@ -88,7 +89,7 @@ public class CoinPaymentHistoryService {
                 .paymentMethod(KAKAOPAY)
                 .isAgree(true)
                 .tid(tid)
-                .coinCount((long) planType.getCoinQuantity())
+                .coinCount(planType.getCoinQuantity())
                 .paymentStatus(PaymentStatus.READY)
                 .member(member)
                 .paymentPrice(dto.amount().total())
@@ -140,13 +141,6 @@ public class CoinPaymentHistoryService {
             throw new KakaoPayException(KakaoPayErrorCode.ALREADY_SUCCESS_ERROR);
         }
         return history;
-    }
-
-    @Transactional
-    public void approve(CoinPaymentHistory history, Coin coin) {
-        history.setCoin(coin);
-        history.changeStatus(PaymentStatus.SUCCESS);
-        coinPaymentRepository.save(history);
     }
 
     @Transactional

--- a/src/main/java/com/example/fitpassserver/domain/coinPaymentHistory/service/CoinPaymentHistoryService.java
+++ b/src/main/java/com/example/fitpassserver/domain/coinPaymentHistory/service/CoinPaymentHistoryService.java
@@ -58,7 +58,7 @@ public class CoinPaymentHistoryService {
                 .build());
     }
 
-    public CoinPaymentHistory createNewCoinPaymentByScheduler(Member member, SubscriptionResponseDTO dto) {
+    public CoinPaymentHistory createNewCoinPaymentByScheduler(Member member, SubscriptionResponseDTO dto, Coin coin) {
         PlanType type = PlanType.getPlanType(dto.item_name());
         if (type == null) {
             throw new PlanException(PlanErrorCode.PLAN_NOT_FOUND);
@@ -68,16 +68,18 @@ public class CoinPaymentHistoryService {
 
         return coinPaymentRepository.save(CoinPaymentHistory.builder()
                 .paymentMethod(KAKAOPAY)
+                .paymentStatus(PaymentStatus.SUCCESS)
                 .isAgree(true)
                 .tid(dto.tid())
                 .coinCount(planType.getCoinQuantity())
-                .paymentStatus(PaymentStatus.READY)
+                .coin(coin)
                 .member(member)
                 .paymentPrice(dto.amount().total())
                 .build());
     }
 
-    public CoinPaymentHistory createNewCoinPaymentByPlan(Member member, String tid, PlanSubscriptionResponseDTO dto) {
+    public CoinPaymentHistory createNewCoinPaymentByPlan(Member member, PlanSubscriptionResponseDTO dto,
+                                                         Coin coin) {
         PlanType type = PlanType.getPlanType(dto.itemName());
         if (type == null) {
             throw new PlanException(PlanErrorCode.PLAN_NAME_NOT_FOUND);
@@ -88,9 +90,10 @@ public class CoinPaymentHistoryService {
         return coinPaymentRepository.save(CoinPaymentHistory.builder()
                 .paymentMethod(KAKAOPAY)
                 .isAgree(true)
-                .tid(tid)
+                .paymentStatus(PaymentStatus.SUCCESS)
+                .coin(coin)
+                .tid(dto.tid())
                 .coinCount(planType.getCoinQuantity())
-                .paymentStatus(PaymentStatus.READY)
                 .member(member)
                 .paymentPrice(dto.amount().total())
                 .build());

--- a/src/main/java/com/example/fitpassserver/domain/plan/controller/PlanPaymentController.java
+++ b/src/main/java/com/example/fitpassserver/domain/plan/controller/PlanPaymentController.java
@@ -1,9 +1,7 @@
 package com.example.fitpassserver.domain.plan.controller;
 
-import com.example.fitpassserver.domain.coin.entity.Coin;
 import com.example.fitpassserver.domain.coin.service.CoinService;
 import com.example.fitpassserver.domain.coinPaymentHistory.dto.request.PlanSubScriptionRequestDTO;
-import com.example.fitpassserver.domain.coinPaymentHistory.entity.CoinPaymentHistory;
 import com.example.fitpassserver.domain.coinPaymentHistory.service.CoinPaymentHistoryService;
 import com.example.fitpassserver.domain.coinPaymentHistory.service.KakaoPaymentService;
 import com.example.fitpassserver.domain.member.annotation.CurrentMember;
@@ -57,12 +55,7 @@ public class PlanPaymentController {
         planService.checkOriginalPlan(member);
         String memberId = member.getId().toString();
         String tid = planRedisService.getTid(memberId);
-        PlanSubscriptionResponseDTO dto = paymentService.approveSubscription(pgToken, tid);
-        CoinPaymentHistory history = coinPaymentHistoryService.createNewCoinPaymentByPlan(member, tid, dto);
-        Coin coin = coinService.createSubscriptionNewCoin(member, history,
-                planService.createNewPlan(member, dto.itemName(), dto.sid()));
-        coinPaymentHistoryService.approve(history, coin);
-        smsCertificationUtil.sendPlanPaymentSMS(member.getPhoneNumber(), dto.itemName(), dto.amount().total());
+        PlanSubscriptionResponseDTO dto = paymentService.approveSubscription(member, pgToken, tid);
         planRedisService.deleteTid(memberId);
         return ApiResponse.onSuccess(dto);
     }

--- a/src/main/java/com/example/fitpassserver/domain/plan/dto/event/PlanPaymentAllSuccessEvent.java
+++ b/src/main/java/com/example/fitpassserver/domain/plan/dto/event/PlanPaymentAllSuccessEvent.java
@@ -1,0 +1,8 @@
+package com.example.fitpassserver.domain.plan.dto.event;
+
+public record PlanPaymentAllSuccessEvent(
+        String planName,
+        String phoneNumber,
+        int totalAmount
+) {
+}

--- a/src/main/java/com/example/fitpassserver/domain/plan/dto/event/PlanSuccessEvent.java
+++ b/src/main/java/com/example/fitpassserver/domain/plan/dto/event/PlanSuccessEvent.java
@@ -1,0 +1,11 @@
+package com.example.fitpassserver.domain.plan.dto.event;
+
+import com.example.fitpassserver.domain.member.entity.Member;
+import com.example.fitpassserver.domain.plan.dto.response.PlanSubscriptionResponseDTO;
+
+public record PlanSuccessEvent(
+        Member member,
+        PlanSubscriptionResponseDTO dto
+
+) {
+}

--- a/src/main/java/com/example/fitpassserver/domain/plan/dto/event/RegularSubscriptionApprovedEvent.java
+++ b/src/main/java/com/example/fitpassserver/domain/plan/dto/event/RegularSubscriptionApprovedEvent.java
@@ -1,0 +1,10 @@
+package com.example.fitpassserver.domain.plan.dto.event;
+
+import com.example.fitpassserver.domain.plan.dto.response.SubscriptionResponseDTO;
+import com.example.fitpassserver.domain.plan.entity.Plan;
+
+public record RegularSubscriptionApprovedEvent(
+        Plan plan,
+        SubscriptionResponseDTO dto
+) {
+}

--- a/src/main/java/com/example/fitpassserver/domain/plan/entity/Plan.java
+++ b/src/main/java/com/example/fitpassserver/domain/plan/entity/Plan.java
@@ -77,4 +77,10 @@ public class Plan extends BaseEntity {
         this.planDate = planDate.plusMonths(1);
     }
 
+    public void updatePlanSubscriptionInfo() {
+        updatePlanDate();
+        setPaymentStatus(PaymentStatus.SUCCESS);
+        addPaymentCount();
+    }
+
 }

--- a/src/main/java/com/example/fitpassserver/domain/plan/listener/PlanSubscriptionEventListener.java
+++ b/src/main/java/com/example/fitpassserver/domain/plan/listener/PlanSubscriptionEventListener.java
@@ -1,0 +1,64 @@
+package com.example.fitpassserver.domain.plan.listener;
+
+import com.example.fitpassserver.domain.coin.entity.Coin;
+import com.example.fitpassserver.domain.coin.service.CoinService;
+import com.example.fitpassserver.domain.coinPaymentHistory.entity.CoinPaymentHistory;
+import com.example.fitpassserver.domain.coinPaymentHistory.service.CoinPaymentHistoryService;
+import com.example.fitpassserver.domain.member.entity.Member;
+import com.example.fitpassserver.domain.member.sms.util.SmsCertificationUtil;
+import com.example.fitpassserver.domain.plan.dto.event.PlanPaymentAllSuccessEvent;
+import com.example.fitpassserver.domain.plan.dto.event.PlanSuccessEvent;
+import com.example.fitpassserver.domain.plan.dto.event.RegularSubscriptionApprovedEvent;
+import com.example.fitpassserver.domain.plan.dto.response.PlanSubscriptionResponseDTO;
+import com.example.fitpassserver.domain.plan.entity.Plan;
+import com.example.fitpassserver.domain.plan.service.PlanService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PlanSubscriptionEventListener {
+    private final SmsCertificationUtil smsCertificationUtil;
+    private final CoinPaymentHistoryService coinPaymentHistoryService;
+    private final CoinService coinService;
+    private final PlanService planService;
+
+    @EventListener
+    @Transactional
+    public void handle(PlanSuccessEvent event) {
+        Member member = event.member();
+        PlanSubscriptionResponseDTO dto = event.dto();
+        Plan plan = planService.createNewPlan(member, dto.itemName(), dto.sid());
+        Coin coin = coinService.createSubscriptionNewCoin(member, plan);
+        CoinPaymentHistory history = coinPaymentHistoryService.createNewCoinPaymentByPlan(event.member(), dto,
+                coin);
+        coinService.setCoinAndCoinPayment(coin, history);
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Async
+    public void handle(PlanPaymentAllSuccessEvent event) {
+        smsCertificationUtil.sendPlanPaymentSMS(event.phoneNumber(), event.planName(), event.totalAmount());
+        log.info("{} 에게 문자 발송 완료", event.phoneNumber());
+    }
+
+    @EventListener
+    @Transactional
+    public void handle(RegularSubscriptionApprovedEvent event) {
+        Plan plan = event.plan();
+        Member member = plan.getMember();
+        Coin coin = coinService.createSubscriptionNewCoin(member, plan);
+        CoinPaymentHistory history = coinPaymentHistoryService.createNewCoinPaymentByScheduler(member, event.dto(),
+                coin);
+        coinService.setCoinAndCoinPayment(coin, history);
+        planService.updatePlanInfo(plan, history);
+    }
+
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #167 

## 📌 개요
- 카카오페이 결제 승인 후 구매내역과 코인 엔티티를 생성하는데 트랜잭션 원자성에 대한 에러가 있었음 
- 각각 개별 트랜잭션으로 이뤄져 있으므로, 코인 엔티티는 생성이 되었는데 구매내역 엔티티는 도중 롤백되어 양방향 매핑이 되지 않아, 구매내역 조회할 때 500에러 발생
- 구매내역이나 코인 엔티티가 각각 생성될 때 하나가 롤백되면 다른 하나도 롤백되어야 맞으므로 한 트랜잭션으로 묶음
- 카카오페이 결제 승인 완료 -> **완료 후 트리거** -> 한 트랜잭션으로 묶음 = (코인 엔티티 생성+ 구매내역 엔티티 생성 + 둘을 양방향 매핑해줌) -> **최종 커밋 완료 후 문자 발송 트리거** -> 문자 발송(비동기)
- 문자 발송은 시간 지체를 고려해 비동기로 처리

## 🔁 변경 사항 (커밋 코드와 함께)
[✨ feat(CoinEvent): 트랜잭션 커밋 성공 후 보낼 event DTO 생성](https://github.com/UMC-7-FIT-PASS/Fitpass-server/commit/aab6b4b7fbed8b7e30ea719346c1dc7b48f0e73d)

[✨ feat(CoinListener): 결제 성공 event Listener 생성](https://github.com/UMC-7-FIT-PASS/Fitpass-server/commit/49fa2215181dc1a3ce6d35033c73ead5bc737b69)

[:refactor: recycle(Coin): event 관련 비즈니스, 도메인 로직 변경](https://github.com/UMC-7-FIT-PASS/Fitpass-server/commit/4fd4a9f3d0a20e962f511525aa49584d6a261c7b)


[✨ feat(PlanListener): plan 결제 성공 event Listener 생성](https://github.com/UMC-7-FIT-PASS/Fitpass-server/commit/a582150a7348817f34fa686c1131907e4c450bfe)


[✨ feat(PlanListener): plan 결제 성공 event Listener 생성](https://github.com/UMC-7-FIT-PASS/Fitpass-server/commit/76245cbb89db70e527205d8ad6237ba493d16cf6)


[♻️ refactor(PlanService): event 기반 plan, coin, history 업데이트 비즈니스 로직 리팩토링](https://github.com/UMC-7-FIT-PASS/Fitpass-server/commit/820a5f80024bbf4f13982f379de6321f4b3dc55c)

[♻️ refactor(PlanScheduler): PlanScheduler event 기반으로 로직 수정](https://github.com/UMC-7-FIT-PASS/Fitpass-server/commit/b4455165dcbc9a6ebda98ec510daa1522846dcbe)

[🐛 bug(Plan): Plan 활성화되었는지 체크하는 메서드 버그 수정](https://github.com/UMC-7-FIT-PASS/Fitpass-server/commit/07231c02b5f276d5a7258ae6ae3187c2107a0016)
## 📸 스크린샷 (필수 x)


## 👀 기타 더 이야기해볼 점 (필수 x)

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
