### PR TITLE
✨ [Feat] : 보유패스 조회 페이지네이션 변경 API 분리

### DIFF
--- a/src/main/java/com/example/fitpassserver/domain/fitness/controller/MemberFitnessController.java
+++ b/src/main/java/com/example/fitpassserver/domain/fitness/controller/MemberFitnessController.java
@@ -43,14 +43,28 @@ public class MemberFitnessController {
     }
 
     @Operation(
-            summary = "보유 패스 조회",
-            description = "사용자의 보유 패스 정보를 조회합니다. 패스 상태는 3가지(NONE, PROGRESS, DONE)로 나눠서 조회됩니다."
+            summary = "보유 패스 조회(NONE, PROGRESS)",
+            description = "사용자의 보유 패스 정보를 조회합니다. 패스 상태는 2가지(NONE, PROGRESS)로 나눠서 조회됩니다."
     )
     @GetMapping
-    public ApiResponse<MemberFitnessResDTO.MemberFitnessGroupDTO> getPassList(
+    public ApiResponse<MemberFitnessResDTO.NoneProgressGroupDTO> getPassList1(
             @Parameter(description = "현재 인증된 사용자 정보", hidden = true)
             @CurrentMember Member member) {
-        MemberFitnessResDTO.MemberFitnessGroupDTO result = memberFitnessService.getPassList(member.getLoginId());
+        MemberFitnessResDTO.NoneProgressGroupDTO result = memberFitnessService.getNoneAndProgressPassList1(member.getLoginId());
+        return ApiResponse.onSuccess(result);
+    }
+
+    @Operation(
+            summary = "보유 패스 조회(DONE, REVIEWED)",
+            description = "사용자의 보유 패스 정보를 조회합니다. 패스 상태는 2가지(DONE, REVIEWED)로 나눠서 조회됩니다."
+    )
+    @GetMapping("/page")
+    public ApiResponse<MemberFitnessResDTO.PagedDoneReviewedGroupDTO> getPassList2(
+            @RequestParam(required = false) Long cursor,
+            @RequestParam int size,
+            @Parameter(description = "현재 인증된 사용자 정보", hidden = true)
+            @CurrentMember Member member) {
+        MemberFitnessResDTO.PagedDoneReviewedGroupDTO result = memberFitnessService.getDoneAndReviewedPassList(cursor, size, member.getLoginId());
         return ApiResponse.onSuccess(result);
     }
 

--- a/src/main/java/com/example/fitpassserver/domain/fitness/dto/response/MemberFitnessResDTO.java
+++ b/src/main/java/com/example/fitpassserver/domain/fitness/dto/response/MemberFitnessResDTO.java
@@ -52,18 +52,31 @@ public class MemberFitnessResDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
-    public static class MemberFitnessGroupDTO {
+    public static class NoneProgressGroupDTO {
         @Schema(description = "NONE 상태의 패스 리스트")
         private List<MemberFitnessPreviewDTO> none;
 
         @Schema(description = "PROGRESS 상태의 패스 리스트")
         private List<MemberFitnessPreviewDTO> progress;
-
-        @Schema(description = "DONE 상태의 패스 리스트")
-        private List<MemberFitnessPreviewDTO> done;
-
-        @Schema(description = "REVIEWED 상태의 패스 리스트")
-        private List<MemberFitnessPreviewDTO> reviewed;
     }
 
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class DoneReviewedGroupDTO {
+        @Schema(description = "DONE 상태의 패스 리스트")
+        private List<MemberFitnessResDTO.MemberFitnessPreviewDTO> done;
+        @Schema(description = "REVIEWED 상태의 패스 리스트")
+        private List<MemberFitnessResDTO.MemberFitnessPreviewDTO> reviewed;
+    }
+
+    @Getter
+    @Builder
+    public static class PagedDoneReviewedGroupDTO{
+        public DoneReviewedGroupDTO group;
+        public boolean hasNext;
+        public Long nextCursor;
+    }
 }

--- a/src/main/java/com/example/fitpassserver/domain/fitness/repository/MemberFitnessRepository.java
+++ b/src/main/java/com/example/fitpassserver/domain/fitness/repository/MemberFitnessRepository.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -38,4 +39,10 @@ public interface MemberFitnessRepository extends JpaRepository<MemberFitness, Lo
     int countAllByActiveTimeGreaterThanEqualAndActiveTimeLessThan(LocalDateTime greaterThan, LocalDateTime lessThan);
 
     List<MemberFitness> findAllByStatusIsAndCreatedAtLessThan(Status status, LocalDateTime createdAt);
+
+    @Query("SELECT m FROM MemberFitness m WHERE m.member.id = :memberId AND m.status IN :statuses ORDER BY m.id DESC")
+    Slice<MemberFitness> findByMemberAndStatusInFirstPage(@Param("memberId") Long memberId, @Param("statuses") List<Status> statuses, Pageable pageable);
+
+    @Query("SELECT m FROM MemberFitness m WHERE m.member.id = :memberId AND m.status IN :statuses AND m.id < :cursorId ORDER BY m.id DESC")
+    Slice<MemberFitness> findByMemberAndStatusInWithCursor(@Param("memberId") Long memberId, @Param("statuses") List<Status> statuses, @Param("cursorId") Long cursorId, Pageable pageable);
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #242

## 📌 개요
- 보유패스 조회 시 사용 가능패스, 사용완료 패스 API 분리

## 🔁 변경 사항 (커밋 코드와 함께)
35965f95d0f40900fd2bf319517cd597da89c4f4
## 📸 스크린샷 (필수 x)

## 👀 기타 더 이야기해볼 점 (필수 x)
나중에 프론트 여유 있을 때 머지할 예정입니다. 머지하지 말아주세요

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
